### PR TITLE
lift-json: Custom typehint fieldname

### DIFF
--- a/framework/lift-base/lift-json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/framework/lift-base/lift-json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -57,7 +57,7 @@ object Extraction {
    * </pre>
    */
   def decompose(a: Any)(implicit formats: Formats): JValue = {
-    def prependTypeHint(clazz: Class[_], o: JObject) = JField("jsonClass", JString(formats.typeHints.hintFor(clazz))) ++ o
+    def prependTypeHint(clazz: Class[_], o: JObject) = JField(formats.typeHints.fieldName, JString(formats.typeHints.hintFor(clazz))) ++ o
 
     def mkObject(clazz: Class[_], fields: List[JField]) = formats.typeHints.containsHint_?(clazz) match {
       case true  => prependTypeHint(clazz, JObject(fields))
@@ -219,8 +219,8 @@ object Extraction {
       if (custom.isDefinedAt(constructor.targetType, json)) custom(constructor.targetType, json)
       else json match {
         case JNull => null
-        case JObject(JField("jsonClass", JString(t)) :: xs) => mkWithTypeHint(t, xs)
-        case JField(_, JObject(JField("jsonClass", JString(t)) :: xs)) => mkWithTypeHint(t, xs)
+        case JObject(JField(formats.typeHints.fieldName, JString(t)) :: xs) => mkWithTypeHint(t, xs)
+        case JField(_, JObject(JField(formats.typeHints.fieldName, JString(t)) :: xs)) => mkWithTypeHint(t, xs)
         case _ => instantiate
       }
     }

--- a/framework/lift-base/lift-json/src/main/scala/net/liftweb/json/Formats.scala
+++ b/framework/lift-base/lift-json/src/main/scala/net/liftweb/json/Formats.scala
@@ -90,7 +90,8 @@ trait Serializer[A] {
  * implicit val formats = DefaultFormats.withHints(hints)
  * </pre>
  */
-trait TypeHints {  
+trait TypeHints {
+  val fieldName = "jsonClass"
   val hints: List[Class[_]]
   
   /** Return hint for given type.

--- a/framework/lift-base/lift-json/src/test/scala/net/liftweb/json/SerializationExamples.scala
+++ b/framework/lift-base/lift-json/src/test/scala/net/liftweb/json/SerializationExamples.scala
@@ -153,7 +153,21 @@ object FullTypeHintExamples extends TypeHintExamples {
   "Option of ambiguous parameterized field decomposition example" in {
     val o = OptionOfAmbiguousP(Some(Falcon(200.0)))
     
-    val ser = swrite(o)    
+    val ser = swrite(o)
+    read[OptionOfAmbiguousP](ser) mustEqual o
+  }
+
+  "Option of ambiguous parameterized field decomposition with custom typehints example" in {
+    implicit val formats = Serialization.formats(new TypeHints {
+      val hints = List(classOf[Falcon], classOf[Chicken])
+      override val fieldName = "@c"
+      def hintFor(clazz: Class[_]) = clazz.getName.substring(clazz.getName.lastIndexOf("."))
+      def classFor(hint: String) = hints find (hintFor(_) == hint)
+    })
+    val o = OptionOfAmbiguousP(Some(Falcon(200.0)))
+
+    val ser = swrite(o)
+    ser mustEqual """{"opt":{"@c":".Falcon","weight":200.0}}"""
     read[OptionOfAmbiguousP](ser) mustEqual o
   }
 }


### PR DESCRIPTION
Motivation: Integration with a 3rd party service that already produces typehints in the JSON output, just with a different field name and naming scheme. Since it is already possible to implement custom TypeHints, the only thing I found missing was to change the name of the field being used for the type hints.
